### PR TITLE
Fix class mapping for building instance segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ data/sample.laz
 
 分类编码要求：
 ```
-0: others
-1: roof
-2: wall
-3: door_window
-4: awning
-5: ground
-6: vegetation
+0: awning
+1: door_window
+2: ground
+3: others
+4: roof
+5: vegetation
+6: wall
 ```
 
-其中 `roof=1`, `wall=2`, `door_window=3` 将用于单体化分割。
+其中 `roof=4`, `wall=6`, `door_window=1` 将用于单体化分割。
 
 ---
 

--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -3,16 +3,24 @@ import numpy as np
 import os
 from typing import Tuple
 
-# 与你给的分类编码保持一致
-CLASS_NAMES = ["others", "roof", "wall", "door_window", "awning", "ground", "vegetation"]
+# 分类编码：0: awning, 1: door_window, 2: ground, 3: others, 4: roof, 5: vegetation, 6: wall
+CLASS_NAMES = [
+    "awning",
+    "door_window",
+    "ground",
+    "others",
+    "roof",
+    "vegetation",
+    "wall",
+]
 CLASS_COLORS = np.array([
-    [0.5, 0.5, 0.5],
-    [0.8, 0.2, 0.2],
-    [0.2, 0.8, 0.2],
-    [0.2, 0.2, 0.8],
-    [0.8, 0.8, 0.2],
-    [0.6, 0.3, 0.1],
-    [0.2, 0.8, 0.8],
+    [0.8, 0.8, 0.2],  # awning
+    [0.2, 0.2, 0.8],  # door_window
+    [0.6, 0.3, 0.1],  # ground
+    [0.5, 0.5, 0.5],  # others
+    [0.8, 0.2, 0.2],  # roof
+    [0.2, 0.8, 0.8],  # vegetation
+    [0.2, 0.8, 0.2],  # wall
 ], dtype=np.float64)
 
 def read_laz_classification(file_path: str) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/postprocess.py
+++ b/src/postprocess.py
@@ -7,7 +7,7 @@ def _attach_facades(points, classes, instance_ids, search_radius: float = 3.0):
     将 wall/door_window 贴附到最近的 roof 实例（按XY投影的近邻）。
     若找不到邻近roof实例，则保持为0（未分配）。
     """
-    roof_mask = (classes == 1) & (instance_ids > 0)
+    roof_mask = (classes == 4) & (instance_ids > 0)
     if roof_mask.sum() == 0:
         print("[Post] 无可用屋面实例，跳过贴附。")
         return instance_ids
@@ -17,7 +17,7 @@ def _attach_facades(points, classes, instance_ids, search_radius: float = 3.0):
     roof_ids = instance_ids[roof_mask]
     tree = cKDTree(roof_xy)
 
-    target_mask = (classes == 2) | (classes == 3)  # wall 或 door_window
+    target_mask = (classes == 6) | (classes == 1)  # wall 或 door_window
     tgt_xy = points[target_mask][:, :2]
 
     if len(tgt_xy) == 0:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -77,9 +77,9 @@ def run(laz_path: str, grid_size: float = 0.5, min_region_points: int = 100):
     points, classes = read_laz_classification(laz_path)
 
     # 仅保留 roof + wall + door_window，用于后续贴附（roof 主导）
-    roof_mask = classes == 1
-    wall_mask = classes == 2
-    door_mask = classes == 3
+    roof_mask = classes == 4
+    wall_mask = classes == 6
+    door_mask = classes == 1
 
     roof_pts = points[roof_mask]
     if len(roof_pts) < 10:

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -113,7 +113,7 @@ def _rag_prune_and_merge(G: nx.Graph, ridge_thresh: float, merge_thresh: float) 
 def _labels_to_instances_for_roof(points, classes, labels, origin_xy, grid_size):
     """将 roof 点（XY落在网格）映射到对应的分水岭区域ID，作为初步实例ID；非roof先置-1。"""
     inst = np.full(len(points), -1, dtype=np.int64)
-    roof_mask = classes == 1
+    roof_mask = classes == 4
     H, W = labels.shape
     ix, iy = _grid_index(points[roof_mask, 0], points[roof_mask, 1], origin_xy, grid_size)
     # 限定到网格范围


### PR DESCRIPTION
## Summary
- Reorder `CLASS_NAMES` and `CLASS_COLORS` for new class scheme (awning=0, door_window=1, ground=2, others=3, roof=4, vegetation=5, wall=6)
- Update preprocessing, segmentation, and postprocessing logic to use roof=4, wall=6, door_window=1
- Refresh README documentation to reflect updated class IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a600a63b9c832ebf0dbe0a62e3652a